### PR TITLE
SuperMaaS image compatibility changes

### DIFF
--- a/install-deps.R
+++ b/install-deps.R
@@ -1,0 +1,1 @@
+renv::restore(prompt=FALSE)

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.3",
+    "Version": "3.6.3",
     "Repositories": [
       {
         "Name": "CRAN",

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "3.6.3",
+    "Version": "3.5.2",
     "Repositories": [
       {
         "Name": "CRAN",


### PR DESCRIPTION
The debian-slim image only has access to R 3.5.2, so we modified the Renv to reflect that for now.