### PR TITLE
Update download timeout for install-deps.R

### DIFF
--- a/install-deps.R
+++ b/install-deps.R
@@ -7,6 +7,7 @@ if (!dir.exists(gadmDir)) {
   ### download the GADM shape file with given URL
   gadmUrl = "https://biogeo.ucdavis.edu/data/gadm3.6/gadm36_levels_shp.zip"
   gadmZip = file.path(gadmDir, "gadm36_levels_shp.zip")
+  options(download.file.method = "libcurl", url.method = "libcurl", timeout = 300)
   download.file(url=gadmUrl, destfile=gadmZip)
   unzip(zipfile=gadmZip, exdir = gadmDir,
         files=grep(unzip(zipfile=gadmZip, list=TRUE)$Name, pattern="gadm36_*.*", value=TRUE, ignore.case = TRUE))


### PR DESCRIPTION
* Change the download timeout from 60 seconds to 5 minutes (300
seconds)
* This is due to potentially slow connections (in the wild) not being
able to download the large shape files fast enough.